### PR TITLE
Update develop CI cycle

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -26,6 +26,7 @@ jobs:
         uses: technote-space/get-diff-action@v6.1.0
         id: git_diff
         with:
+          GET_FILE_DIFF: true
           PATTERNS: |
             magic_monkey/**/*.py
             setup.py
@@ -70,6 +71,7 @@ jobs:
         uses: technote-space/get-diff-action@v6.1.0
         id: git_diff
         with:
+          GET_FILE_DIFF: true
           PATTERNS: |
             magic_monkey/**/*.py
             setup.py

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -1,4 +1,4 @@
-name: Development build
+name: Development PR builds
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
       - 'magic_monkey/**/*.py'
       - 'setup.py'
       - '!.github/**'
-      - '.github/workflows/build-develop.yml'
+      - '.github/workflows/*-develop.yml'
       - 'containers/**/*'
 
 jobs:
@@ -29,7 +29,7 @@ jobs:
           PATTERNS: |
             magic_monkey/**/*.py
             setup.py
-            .github/workflows/build-develop.yml
+            .github/workflows/*-develop.yml
             containers/**/*
       -
         name: Set up Docker Buildx
@@ -52,8 +52,8 @@ jobs:
           pull: true
           push: true
           set: |
-            nogpu.tags=docker.io/avcaron/mrhardi-nogpu:dev
-            latest.tags=docker.io/avcaron/mrhardi-gpu:dev
+            nogpu.tags=docker.io/avcaron/mrhardi-nogpu:pr-${{ github.event.number }}
+            latest.tags=docker.io/avcaron/mrhardi-gpu:pr-${{ github.event.number }}
             mrhardi_cloner.args.mrhardi_ver=${{ github.head_ref }}
 
   mrhardi-creative-packaging:
@@ -73,7 +73,7 @@ jobs:
           PATTERNS: |
             magic_monkey/**/*.py
             setup.py
-            .github/workflows/build-develop.yml
+            .github/workflows/*-develop.yml
             containers/**/*
       -
         name: Maximize disk usage
@@ -108,16 +108,17 @@ jobs:
           export SINGULARITY_TMPDIR="$(pwd)/sif_tmp"
           export SINGULARITY_CACHEDIR="$(pwd)/sif_cache"
           echo "Caching and temping singularity at : $SINGULARITY_CACHEDIR and $SINGULARITY_TMPDIR"
-          singularity build mrhardi_dev_gpu.sif docker://avcaron/mrhardi-gpu:dev
+          singularity build mrhardi_dev_gpu.sif docker://avcaron/mrhardi-gpu:pr-${{ github.event.number }}
           echo "${{ secrets.ACR_TOKEN }}" | singularity remote login --username ${{ secrets.ACR_USERNAME }} --password-stdin oras://mrhardi.azurecr.io
-          singularity push mrhardi_dev_gpu.sif oras://mrhardi.azurecr.io/mrHARDI/mrhardi:dev
+          singularity push mrhardi_dev_gpu.sif oras://mrhardi.azurecr.io/mrHARDI/mrhardi:pr-${{ github.event.number }}
       -
         name: Write artifacts manifest
         run: |
+          echo "Warning !!! Artifacts will be deleted when pull request closes" >> artifacts.MANIFEST
           echo "Artifacts pull commands:" >> artifacts.MANIFEST
-          echo "docker pull avcaron/mrhardi-nogpu:dev" >> artifacts.MANIFEST
-          echo "docker pull avcaron/mrhardi-gpu:dev" >> artifacts.MANIFEST
-          echo "singularity pull oras://mrhardi.azurecr.io/mrHARDI/mrhardi:dev" >> artifacts.MANIFEST
+          echo "docker pull avcaron/mrhardi-nogpu:pr-${{ github.event.number }}" >> artifacts.MANIFEST
+          echo "docker pull avcaron/mrhardi-gpu:pr-${{ github.event.number }}" >> artifacts.MANIFEST
+          echo "singularity pull oras://mrhardi.azurecr.io/mrHARDI/mrhardi:pr-${{ github.event.number }}" >> artifacts.MANIFEST
       -
         name: Upload workflow artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/push-develop.yml
+++ b/.github/workflows/push-develop.yml
@@ -1,3 +1,120 @@
-# This file is left intentionally empty for now. Once develop becomes more stable
-# or another branch is chosen, this workflow will increment the patch of the release
-# based on a push event to the branch (see push-master.yml)
+name: Update development artifacts
+
+on:
+  pull_request:
+    branches:
+      - develop
+    types: [closed]
+    paths:
+      - 'magic_monkey/**/*.py'
+      - 'setup.py'
+      - '!.github/**'
+      - '.github/workflows/*-develop.yml'
+      - 'containers/**/*'
+
+jobs:
+  create_docker_dev:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    environment: CI
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Get git diff for the current modifications
+        uses: technote-space/get-diff-action@v6.1.0
+        id: git_diff
+        with:
+          PATTERNS: |
+            magic_monkey/**/*.py
+            setup.py
+            .github/workflows/*-develop.yml
+            containers/**/*
+      - 
+        name: Create CPU docker dev tag from PR tag
+        if: ${{ steps.git_diff.outputs.lines > 0 }}
+        uses: julb/action-copy-docker-tag@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          from: avcaron/mrhardi-nogpu:pr-${{ github.event.number }}
+          tags: |
+            avcaron/mrhardi-nogpu:dev
+      -
+        name: Delete CPU PR tag from dockerhub
+        if: ${{ steps.git_diff.outputs.lines > 0 }}
+        uses: mhl787156/dockerhub-delete-tag-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_SECRET }}
+          organisation: avcaron
+          image: mrhardi-nogpu
+          tag: pr-${{ github.event.number }}
+      - 
+        name: Create GPU docker dev tag from PR tag
+        if: ${{ steps.git_diff.outputs.lines > 0 }}
+        uses: julb/action-copy-docker-tag@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          from: avcaron/mrhardi-gpu:pr-${{ github.event.number }}
+          tags: |
+            avcaron/mrhardi-gpu:dev
+      -
+        name: Delete GPU PR tag from dockerhub
+        if: ${{ steps.git_diff.outputs.lines > 0 }}
+        uses: mhl787156/dockerhub-delete-tag-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_SECRET }}
+          organisation: avcaron
+          image: mrhardi-gpu
+          tag: pr-${{ github.event.number }}
+
+  create_singularity_dev:
+    needs: create_docker_dev
+    runs-on: ubuntu-latest
+    environment: CI
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Get git diff for the current modifications
+        uses: technote-space/get-diff-action@v6.1.0
+        id: git_diff
+        with:
+          PATTERNS: |
+            magic_monkey/**/*.py
+            setup.py
+            .github/workflows/*-develop.yml
+            containers/**/*
+      - 
+        name: Setup singularity
+        if: ${{ steps.git_diff.outputs.lines > 0 }}
+        uses: eWaterCycle/setup-singularity@v7
+        with:
+          singularity-version: 3.7.1
+      -
+        name: Azure Container Registry Login
+        if: ${{ steps.git_diff.outputs.lines > 0 }}
+        uses: Azure/docker-login@v1
+        with:
+          login-server: mrhardi.azurecr.io
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_TOKEN }}
+      -
+        name: Update tag of singularity image
+        if: ${{ steps.git_diff.outputs.lines > 0 }}
+        run: |
+          mkdir sif_tmp sif_cache
+          export SINGULARITY_TMPDIR="$(pwd)/sif_tmp"
+          export SINGULARITY_CACHEDIR="$(pwd)/sif_cache"
+          echo "Caching and temping singularity at : $SINGULARITY_CACHEDIR and $SINGULARITY_TMPDIR"
+          echo "${{ secrets.ACR_TOKEN }}" | singularity remote login --username ${{ secrets.ACR_USERNAME }} --password-stdin oras://mrhardi.azurecr.io
+          singularity pull oras://mrhardi.azurecr.io/mrHARDI/mrhardi:pr-${{ github.event.number }}
+          singularirty push mrhardi_pr_${{ github.event.number }}.sif oras://mrhardi.azurecr.io/mrHARDI/mrhardi:dev
+          az acr repository untag -n mrHARDI -t mrhardi:pr-${{ github.event.number }}

--- a/.github/workflows/push-develop.yml
+++ b/.github/workflows/push-develop.yml
@@ -27,6 +27,7 @@ jobs:
         uses: technote-space/get-diff-action@v6.1.0
         id: git_diff
         with:
+          GET_FILE_DIFF: true
           PATTERNS: |
             magic_monkey/**/*.py
             setup.py
@@ -87,6 +88,7 @@ jobs:
         uses: technote-space/get-diff-action@v6.1.0
         id: git_diff
         with:
+          GET_FILE_DIFF: true
           PATTERNS: |
             magic_monkey/**/*.py
             setup.py

--- a/.github/workflows/push-develop.yml
+++ b/.github/workflows/push-develop.yml
@@ -1,7 +1,10 @@
 name: Update development artifacts
 
 on:
-  workflow_dispatch:
+  workflow_run:
+      workflows: ["Development PR builds"]
+      types:
+        - completed
   pull_request:
     branches:
       - develop

--- a/.github/workflows/push-develop.yml
+++ b/.github/workflows/push-develop.yml
@@ -1,6 +1,7 @@
 name: Update development artifacts
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - develop

--- a/.github/workflows/push-develop.yml
+++ b/.github/workflows/push-develop.yml
@@ -1,10 +1,6 @@
 name: Update development artifacts
 
 on:
-  workflow_run:
-      workflows: ["Development PR builds"]
-      types:
-        - completed
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
Instead of creating one dev image for all PR (high conflict !!!), now an individual image is created for each of them. On a merge with the dev branch, the push_develop action is trigger (finally populated !!!) which updates the dev tag and deletes the PR tag.